### PR TITLE
fix: fixes wrong flattenColorPalette import causing build failures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const plugin = require('tailwindcss/plugin')
-const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default
+const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette')
 const msoBorderColors = require('./msoColors.js')
 
 module.exports = plugin.withOptions(


### PR DESCRIPTION
Tailwind CSS v3 exports flattenColorPalette directly without requiring .default accessor. The plugin was using the old import style which caused "flattenColorPalette is not a function" TypeError.

Updated import from flattenColorPalette.default to flattenColorPalette to match current Tailwind CSS export format.

Fixes #147